### PR TITLE
Fix Translation in deathscreen when stabilised

### DIFF
--- a/addons/OPT/CfgCLibLocalisation.hpp
+++ b/addons/OPT/CfgCLibLocalisation.hpp
@@ -137,6 +137,10 @@ class CfgCLibLocalisation {
 				English = "Stabilise";
 				German = "Stabilisieren";
 			};
+			class IS_STABILISED {
+				English = "Stabilised";
+				German = "Stabilisiert";
+			};
 			class STABILISING {
 				English = "Stabilising";
 				German = "Stabilisieren";

--- a/addons/OPT/REVIVE/fn_dialog.sqf
+++ b/addons/OPT/REVIVE/fn_dialog.sqf
@@ -138,7 +138,7 @@ GVAR(startzeit) = time;
 	// Zeitausgabe bis Auto Respwan
 	if (player getVariable ["OPT_isStabilized", 1] == 1) then 
 	{
-		_BleedoutBar_Text ctrlSetText format ["%1",MLOC(STABILISE)]; 
+		_BleedoutBar_Text ctrlSetText format ["%1",MLOC(IS_STABILISED)]; 
 		_BleedoutBar progressSetPosition 1.0; 
 		_BleedoutBar_Text ctrlSetTextColor [0, 1, 0, 1];
 		_BleedoutBar ctrlSetTextColor [0, 1, 0, 1];


### PR DESCRIPTION
Small translation fix in the deathscreen. If a person is stabilised it no longer shows stabilise/stabilisieren. Instead it shows stabilised/stabilisiert. 